### PR TITLE
updating to 1.5 and harmony 2.0

### DIFF
--- a/CasksEverywhere/CaskPatch.cs
+++ b/CasksEverywhere/CaskPatch.cs
@@ -1,4 +1,4 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using StardewValley.Objects;
 using System.Reflection;
 

--- a/CasksEverywhere/CasksEverywhere.csproj
+++ b/CasksEverywhere/CasksEverywhere.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.1.0</Version>
-    <TargetFramework>net452</TargetFramework>
-
+    <Version>1.1.1</Version>
+    <TargetFramework>net5.0</TargetFramework>
     <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/CasksEverywhere/CasksEverywhereMod.cs
+++ b/CasksEverywhere/CasksEverywhereMod.cs
@@ -1,5 +1,6 @@
-﻿using Harmony;
+﻿using HarmonyLib;
 using StardewModdingAPI;
+using StardewValley.Objects;
 using System.Reflection;
 
 namespace CasksEverywhere
@@ -10,9 +11,8 @@ namespace CasksEverywhere
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
-            HarmonyInstance instance = HarmonyInstance.Create(helper.ModRegistry.ModID);
-
-            instance.PatchAll(Assembly.GetExecutingAssembly());
+            var harmony = new Harmony(helper.ModRegistry.ModID);
+            harmony.PatchAll(Assembly.GetCallingAssembly());
         }
     }
 }


### PR DESCRIPTION
Kept throwing a weird error on line 15 in `CasksEverywhereMod.cs` when I tried to maintain .NET 4.52 and Pathoschild.Stardew.ModBuildConfig 3.3.0:

```
Reference to type 'Assembly' claims it is defined in 'System.Runtime', but it could not be found
```

I'm not super familiar with C#, but when I updated the dependencies that seemed to fix it. 

No idea if this update works yet -- testing a save file with casks would be very appreciated!  


