### PR TITLE
[ModUpdateMenu] Fix Clicking Links

### DIFF
--- a/ModUpdateMenu/Menus/UpdateMenu.cs
+++ b/ModUpdateMenu/Menus/UpdateMenu.cs
@@ -185,9 +185,13 @@ namespace ModUpdateMenu.Menus
         {
             if (this.SMAPIText != null && this.SMAPIComponent.containsPoint(x, y))
             {
+                Game1.playSound("bigSelect");
                 try
                 {
-                    Process.Start("https://smapi.io");
+                    Process.Start(new ProcessStartInfo("https://smapi.io")
+                    {
+                        UseShellExecute = true
+                    });
                 }
                 catch
                 {
@@ -387,7 +391,10 @@ namespace ModUpdateMenu.Menus
                 if (which.UpdateURLType != "???")
                     try
                     {
-                        Process.Start(which.UpdateURL);
+                        Process.Start(new ProcessStartInfo(which.UpdateURL)
+                        {
+                            UseShellExecute = true
+                        });
                     }
                     catch
                     {

--- a/ModUpdateMenu/ModUpdateMenu.csproj
+++ b/ModUpdateMenu/ModUpdateMenu.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.1</Version>
-    <TargetFramework>net452</TargetFramework>
+    <Version>1.4.2</Version>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since .NET Core, there's a breaking change in how `Process.Start()` handles string inputs. As a result, just passing a URL as a string no longer results in the URL being opened in the user's default browser. To address this, we need to construct a `ProcessStartInfo` instance and set `UseShellExecute` to `true`.

This PR also updates ModUpdateMenu to the most recent version of `ModBuildConfig` and sets the target framework to .NET 5.0.