### PR TITLE
Migrated to SMAPI 4.0.0 and Stardew Valley 1.6

### DIFF
--- a/BetterArtisanGoodIcons/ArtisanGood.cs
+++ b/BetterArtisanGoodIcons/ArtisanGood.cs
@@ -3,11 +3,11 @@
     /// <summary>The artisan goods that we add unique icons foor.</summary>
     internal enum ArtisanGood
     {
-        Jelly = 344,
-        Pickles = 342,
-        Wine = 348,
-        Juice = 350,
-        Honey = 340
+        Jelly = 130,
+        Pickles = 128,
+        Wine = 123,
+        Juice = 125,
+        Honey = 340         // Honey is still on springObject sheet and has a different index
     }
 
 }

--- a/BetterArtisanGoodIcons/ArtisanGoodTextureProvider.cs
+++ b/BetterArtisanGoodIcons/ArtisanGoodTextureProvider.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework.Graphics;
 using StardewValley;
 using StardewValley.GameData.Objects;
+using StardewValley.ItemTypeDefinitions;
 using System.Collections.Generic;
 using SObject = StardewValley.Object;
 
@@ -89,15 +90,14 @@ namespace BetterArtisanGoodIcons
             if (!this.GetIndexOfSource(item, out string sourceIndex))
                 return false;
 
+            ParsedItemData source = ItemRegistry.GetDataOrErrorItem("(O)" + item.preservedParentSheetIndex.Value);
             //Get the name of the item from its index, and from that, a new sprite.
-            string sourceName = ItemRegistry.GetDataOrErrorItem("(O)" + item.preservedParentSheetIndex.Value).InternalName;
+            string sourceName = source.InternalName;
             if (!this.positions.TryGetValue(sourceName, out mainPosition))
                 return false;
 
             textureSheet = this.spriteSheet;
-            iconPosition = sourceIndex != null
-                ? Game1.getSourceRectForStandardTileSheet(Game1.objectSpriteSheet, int.Parse(sourceIndex), 16, 16)
-                : Rectangle.Empty;
+            iconPosition = sourceIndex != null ? source.GetSourceRect() : Rectangle.Empty;
             return true;
         }
     }

--- a/BetterArtisanGoodIcons/ArtisanGoodsManager.cs
+++ b/BetterArtisanGoodIcons/ArtisanGoodsManager.cs
@@ -12,7 +12,6 @@ namespace BetterArtisanGoodIcons
     internal static class ArtisanGoodsManager
     {
         public static IMonitor Monitor;
-
         /// <summary>Texture managers that get the correct texture for each item.</summary>
         private static readonly IList<ArtisanGoodTextureProvider> TextureProviders = new List<ArtisanGoodTextureProvider>();
 
@@ -24,8 +23,6 @@ namespace BetterArtisanGoodIcons
         {
             Monitor = monitor;
             config = helper.ReadConfig<BetterArtisanGoodIconsConfig>();
-            Monitor.Log($"Init", LogLevel.Trace);
-
 
             foreach (ArtisanGoodTextureProvider provider in ContentSourceManager.GetTextureProviders(helper, monitor))
                 TextureProviders.Add(provider);
@@ -42,7 +39,6 @@ namespace BetterArtisanGoodIcons
             {
                 if (manager.GetDrawInfo(output, ref textureSheet, ref mainPosition, ref iconPosition))
                 {
-//                    Monitor.Log($"ArtisanGoodTextureProvider GetDrawInfo succeed", LogLevel.Trace);
                     if (config.DisableSmallSourceIcons)
                         iconPosition = Rectangle.Empty;
                     return true;

--- a/BetterArtisanGoodIcons/ArtisanGoodsManager.cs
+++ b/BetterArtisanGoodIcons/ArtisanGoodsManager.cs
@@ -11,6 +11,8 @@ namespace BetterArtisanGoodIcons
     /// <summary>Manages textures for all artisan goods.</summary>
     internal static class ArtisanGoodsManager
     {
+        public static IMonitor Monitor;
+
         /// <summary>Texture managers that get the correct texture for each item.</summary>
         private static readonly IList<ArtisanGoodTextureProvider> TextureProviders = new List<ArtisanGoodTextureProvider>();
 
@@ -20,7 +22,10 @@ namespace BetterArtisanGoodIcons
         /// <summary>Initializes the manager.</summary>
         internal static void Init(IModHelper helper, IMonitor monitor)
         {
+            Monitor = monitor;
             config = helper.ReadConfig<BetterArtisanGoodIconsConfig>();
+            Monitor.Log($"Init", LogLevel.Trace);
+
 
             foreach (ArtisanGoodTextureProvider provider in ContentSourceManager.GetTextureProviders(helper, monitor))
                 TextureProviders.Add(provider);
@@ -37,6 +42,7 @@ namespace BetterArtisanGoodIcons
             {
                 if (manager.GetDrawInfo(output, ref textureSheet, ref mainPosition, ref iconPosition))
                 {
+//                    Monitor.Log($"ArtisanGoodTextureProvider GetDrawInfo succeed", LogLevel.Trace);
                     if (config.DisableSmallSourceIcons)
                         iconPosition = Rectangle.Empty;
                     return true;

--- a/BetterArtisanGoodIcons/BetterArtisanGoodIcons.csproj
+++ b/BetterArtisanGoodIcons/BetterArtisanGoodIcons.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.5.0</Version>
-    <TargetFramework>net452</TargetFramework>
-
+    <Version>1.5.1</Version>
+    <TargetFramework>net5.0</TargetFramework>
     <EnableHarmony>true</EnableHarmony>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BetterArtisanGoodIcons/BetterArtisanGoodIcons.csproj
+++ b/BetterArtisanGoodIcons/BetterArtisanGoodIcons.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.5.1</Version>
-    <TargetFramework>net5.0</TargetFramework>
+    <Version>1.5.2</Version>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableHarmony>true</EnableHarmony>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/BetterArtisanGoodIcons/BetterArtisanGoodIconsMod.cs
+++ b/BetterArtisanGoodIcons/BetterArtisanGoodIconsMod.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using BetterArtisanGoodIcons.Extensions;
-using Harmony;
+using HarmonyLib;
 using StardewModdingAPI;
 using StardewValley.Objects;
 
@@ -20,7 +20,7 @@ namespace BetterArtisanGoodIcons
         {
             ArtisanGoodsManager.Init(this.Helper, this.Monitor);
 
-            HarmonyInstance harmony = HarmonyInstance.Create("cat.betterartisangoodicons");
+            Harmony harmony = new Harmony("cat.betterartisangoodicons");
 
             //Don't need to override draw for Object because artisan goods can't be placed down.
             Type objectType = typeof(StardewValley.Object);

--- a/BetterArtisanGoodIcons/BetterArtisanGoodIconsMod.cs
+++ b/BetterArtisanGoodIcons/BetterArtisanGoodIconsMod.cs
@@ -23,12 +23,15 @@ namespace BetterArtisanGoodIcons
             Harmony harmony = new Harmony("cat.betterartisangoodicons");
 
             //Don't need to override draw for Object because artisan goods can't be placed down.
-            Type objectType = typeof(StardewValley.Object);
+            Type objectType = typeof(ColoredObject);
             IList<Tuple<string, Type, Type>> replacements = new List<Tuple<string, Type, Type>>
             {
                 {"drawWhenHeld", objectType, typeof(Patches.SObjectPatches.DrawWhenHeldPatch)},
                 {"drawInMenu", objectType, typeof(Patches.SObjectPatches.DrawInMenuPatch)},
                 {"draw", objectType, typeof(Patches.SObjectPatches.DrawPatch)},
+                {"drawWhenHeld", typeof(StardewValley.Object), typeof(Patches.SObjectPatches.DrawWhenHeldPatch)},   // 
+                {"drawInMenu", typeof(StardewValley.Object), typeof(Patches.SObjectPatches.DrawInMenuPatch)},       // for honey, since honey is not a ColoredObject
+                {"draw", typeof(StardewValley.Object), typeof(Patches.SObjectPatches.DrawPatch)},                   // 
                 {"draw", typeof(Furniture), typeof(Patches.FurniturePatches.DrawPatch)}
             };
 

--- a/BetterArtisanGoodIcons/Content/ContentPackSource.cs
+++ b/BetterArtisanGoodIcons/Content/ContentPackSource.cs
@@ -17,7 +17,7 @@ namespace BetterArtisanGoodIcons.Content
 
         public override T Load<T>(string path)
         {
-            return this.pack.LoadAsset<T>(path);
+            return this.pack.ModContent.Load<T>(path);
         }
 
         public override IManifest GetManifest()

--- a/BetterArtisanGoodIcons/Content/ModSource.cs
+++ b/BetterArtisanGoodIcons/Content/ModSource.cs
@@ -21,7 +21,7 @@ namespace BetterArtisanGoodIcons.Content
 
         public override T Load<T>(string path)
         {
-            return this.helper.ModContent<T>(path);
+            return this.helper.ModContent.Load<T>(path);
         }
 
         public override IManifest GetManifest()

--- a/BetterArtisanGoodIcons/Content/ModSource.cs
+++ b/BetterArtisanGoodIcons/Content/ModSource.cs
@@ -21,7 +21,7 @@ namespace BetterArtisanGoodIcons.Content
 
         public override T Load<T>(string path)
         {
-            return this.helper.Content.Load<T>(path);
+            return this.helper.ModContent<T>(path);
         }
 
         public override IManifest GetManifest()

--- a/BetterArtisanGoodIcons/Patches/FurniturePatches/DrawPatch.cs
+++ b/BetterArtisanGoodIcons/Patches/FurniturePatches/DrawPatch.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Objects;
 
@@ -16,10 +17,10 @@ namespace BetterArtisanGoodIcons.Patches.FurniturePatches
             if (x == -1)
             {
                 Vector2 drawPos = new Vector2(__instance.boundingBox.X, __instance.boundingBox.Y - (__instance.sourceRect.Height * Game1.pixelZoom - __instance.boundingBox.Value.Height));
-                spriteBatch.Draw(Furniture.furnitureTexture, Game1.GlobalToLocal(Game1.viewport, drawPos), new Rectangle?(__instance.sourceRect.Value), Color.White * alpha, 0.0f, Vector2.Zero, (float)Game1.pixelZoom, __instance.Flipped ? SpriteEffects.FlipHorizontally : SpriteEffects.None, __instance.furniture_type.Value == 12 ? 0.0f : (__instance.boundingBox.Value.Bottom - 8) / 10000f);
+                spriteBatch.Draw(Game1.content.Load<Texture2D>(Furniture.furnitureTextureName), Game1.GlobalToLocal(Game1.viewport, drawPos), new Rectangle?(__instance.sourceRect.Value), Color.White * alpha, 0.0f, Vector2.Zero, (float)Game1.pixelZoom, __instance.Flipped ? SpriteEffects.FlipHorizontally : SpriteEffects.None, __instance.furniture_type.Value == 12 ? 0.0f : (__instance.boundingBox.Value.Bottom - 8) / 10000f);
             }
             else
-                spriteBatch.Draw(Furniture.furnitureTexture, Game1.GlobalToLocal(Game1.viewport, new Vector2(x * Game1.tileSize, y * Game1.tileSize - (__instance.sourceRect.Value.Height * Game1.pixelZoom - __instance.boundingBox.Value.Height))), new Rectangle?(__instance.sourceRect.Value), Color.White * alpha, 0.0f, Vector2.Zero, Game1.pixelZoom, __instance.Flipped ? SpriteEffects.FlipHorizontally : SpriteEffects.None, __instance.furniture_type.Value == 12 ? 0.0f : (__instance.boundingBox.Value.Bottom - 8) / 10000f);
+                spriteBatch.Draw(Game1.content.Load<Texture2D>(Furniture.furnitureTextureName), Game1.GlobalToLocal(Game1.viewport, new Vector2(x * Game1.tileSize, y * Game1.tileSize - (__instance.sourceRect.Value.Height * Game1.pixelZoom - __instance.boundingBox.Value.Height))), new Rectangle?(__instance.sourceRect.Value), Color.White * alpha, 0.0f, Vector2.Zero, Game1.pixelZoom, __instance.Flipped ? SpriteEffects.FlipHorizontally : SpriteEffects.None, __instance.furniture_type.Value == 12 ? 0.0f : (__instance.boundingBox.Value.Bottom - 8) / 10000f);
 
             spriteBatch.Draw(Game1.shadowTexture, Game1.GlobalToLocal(Game1.viewport, new Vector2(__instance.boundingBox.Value.Center.X - Game1.tileSize / 2, __instance.boundingBox.Value.Center.Y - (__instance.drawHeldObjectLow.Value ? Game1.tileSize / 2 : Game1.tileSize * 4 / 3))) + new Vector2(Game1.tileSize / 2f, Game1.tileSize * 5f / 6), new Rectangle?(Game1.shadowTexture.Bounds), Color.White * alpha, 0.0f, new Vector2(Game1.shadowTexture.Bounds.Center.X, Game1.shadowTexture.Bounds.Center.Y), 4f, SpriteEffects.None, __instance.boundingBox.Value.Bottom / 10000f);
             spriteBatch.Draw(spriteSheet, Game1.GlobalToLocal(Game1.viewport, new Vector2(__instance.boundingBox.Value.Center.X - Game1.tileSize / 2, __instance.boundingBox.Value.Center.Y - (__instance.drawHeldObjectLow.Value ? Game1.tileSize / 2 : Game1.tileSize * 4 / 3))), new Rectangle?(position), Color.White * alpha, 0.0f, Vector2.Zero, Game1.pixelZoom, SpriteEffects.None, (__instance.boundingBox.Value.Bottom + 1) / 10000f);

--- a/BetterArtisanGoodIcons/Patches/SObjectPatches/DrawInMenuPatch.cs
+++ b/BetterArtisanGoodIcons/Patches/SObjectPatches/DrawInMenuPatch.cs
@@ -1,9 +1,8 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using StardewModdingAPI;
 using StardewValley;
+using StardewValley.ItemTypeDefinitions;
 using System;
-using System.Threading;
 using SObject = StardewValley.Object;
 
 namespace BetterArtisanGoodIcons.Patches.SObjectPatches
@@ -22,8 +21,11 @@ namespace BetterArtisanGoodIcons.Patches.SObjectPatches
 
             //By popular demand, don't show icons near the mouse cursor, which are drawn with lowered transparency.
             if (transparency >= 1 && iconPosition != Rectangle.Empty)
-                spriteBatch.Draw(Game1.objectSpriteSheet, location + new Vector2(Game1.tileSize / 6 * scaleSize, Game1.tileSize / 6 * scaleSize), new Microsoft.Xna.Framework.Rectangle?(iconPosition), Color.White * transparency, 0.0f, new Vector2(4f, 4f), (3f / 2f) * scaleSize, SpriteEffects.None, layerDepth);
+            {
+                ParsedItemData source = ItemRegistry.GetDataOrErrorItem("(O)" + __instance.preservedParentSheetIndex.Value);
 
+                spriteBatch.Draw(source.GetTexture(), location + new Vector2(Game1.tileSize / 6 * scaleSize, Game1.tileSize / 6 * scaleSize), new Microsoft.Xna.Framework.Rectangle?(iconPosition), Color.White * transparency, 0.0f, new Vector2(4f, 4f), (3f / 2f) * scaleSize, SpriteEffects.None, layerDepth);
+            }
             if (drawStackNumber && __instance.maximumStackSize() > 1 && (scaleSize > 0.3 && __instance.Stack != int.MaxValue) && __instance.Stack > 1)
                 Utility.drawTinyDigits(__instance.Stack, spriteBatch, location + new Vector2(Game1.tileSize - Utility.getWidthOfTinyDigitString(__instance.Stack, 3f * scaleSize) + 3f * scaleSize, (float)(Game1.tileSize - 18.0 * scaleSize + 2.0)), 3f * scaleSize, 1f, Color.White);
             if (drawStackNumber && __instance.Quality > 0)
@@ -31,7 +33,7 @@ namespace BetterArtisanGoodIcons.Patches.SObjectPatches
                 float num = __instance.Quality < 4 ? 0.0f : (float)((Math.Cos(Game1.currentGameTime.TotalGameTime.Milliseconds * Math.PI / 512.0) + 1.0) * 0.0500000007450581);
                 spriteBatch.Draw(Game1.mouseCursors, location + new Vector2(12f, Game1.tileSize - 12 + num), new Microsoft.Xna.Framework.Rectangle?(__instance.Quality < 4 ? new Rectangle(338 + (__instance.Quality - 1) * 8, 400, 8, 8) : new Rectangle(346, 392, 8, 8)), Color.White * transparency, 0.0f, new Vector2(4f, 4f), (float)(3.0 * scaleSize * (1.0 + num)), SpriteEffects.None, layerDepth);
             }
-            if (__instance.Category == -22 && (double)__instance.scale.Y < 1.0)
+            if (__instance.Category == -22 && __instance.scale.Y < 1.0)
                 spriteBatch.Draw(Game1.staminaRect, new Rectangle((int)location.X, (int)(location.Y + (Game1.tileSize - 2 * Game1.pixelZoom) * (double)scaleSize), (int)(Game1.tileSize * (double)scaleSize * __instance.scale.Y), (int)((2 * Game1.pixelZoom) * (double)scaleSize)), Utility.getRedToGreenLerpColor(__instance.scale.Y));
 
             return false;

--- a/BetterArtisanGoodIcons/Patches/SObjectPatches/DrawInMenuPatch.cs
+++ b/BetterArtisanGoodIcons/Patches/SObjectPatches/DrawInMenuPatch.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
 using StardewValley;
 using System;
+using System.Threading;
 using SObject = StardewValley.Object;
 
 namespace BetterArtisanGoodIcons.Patches.SObjectPatches

--- a/BetterArtisanGoodIcons/Patches/SObjectPatches/DrawPatch.cs
+++ b/BetterArtisanGoodIcons/Patches/SObjectPatches/DrawPatch.cs
@@ -17,7 +17,6 @@ namespace BetterArtisanGoodIcons.Patches.SObjectPatches
             if (!__instance.readyForHarvest.Value || !__instance.bigCraftable.Value || __instance.heldObject.Value == null || 
                 !ArtisanGoodsManager.GetDrawInfo(__instance.heldObject.Value, out Texture2D spriteSheet, out Rectangle position, out Rectangle iconPosition))
                 return true;
-
             Vector2 vector2 = __instance.getScale() * (float)Game1.pixelZoom;
             Vector2 local = Game1.GlobalToLocal(Game1.viewport, new Vector2((float)(x * Game1.tileSize), (float)(y * Game1.tileSize - Game1.tileSize)));
             Microsoft.Xna.Framework.Rectangle destinationRectangle = new Microsoft.Xna.Framework.Rectangle((int)((double)local.X - (double)vector2.X / 2.0) + (__instance.shakeTimer > 0 ? Game1.random.Next(-1, 2) : 0), (int)((double)local.Y - (double)vector2.Y / 2.0) + (__instance.shakeTimer > 0 ? Game1.random.Next(-1, 2) : 0), (int)((double)Game1.tileSize + (double)vector2.X), (int)((double)(Game1.tileSize * 2) + (double)vector2.Y / 2.0));

--- a/BetterArtisanGoodIcons/Patches/SObjectPatches/DrawPatch.cs
+++ b/BetterArtisanGoodIcons/Patches/SObjectPatches/DrawPatch.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
 using StardewValley;
 using System;
 using SObject = StardewValley.Object;
@@ -16,13 +17,14 @@ namespace BetterArtisanGoodIcons.Patches.SObjectPatches
             if (!__instance.readyForHarvest.Value || !__instance.bigCraftable.Value || __instance.heldObject.Value == null || 
                 !ArtisanGoodsManager.GetDrawInfo(__instance.heldObject.Value, out Texture2D spriteSheet, out Rectangle position, out Rectangle iconPosition))
                 return true;
+
             Vector2 vector2 = __instance.getScale() * (float)Game1.pixelZoom;
             Vector2 local = Game1.GlobalToLocal(Game1.viewport, new Vector2((float)(x * Game1.tileSize), (float)(y * Game1.tileSize - Game1.tileSize)));
             Microsoft.Xna.Framework.Rectangle destinationRectangle = new Microsoft.Xna.Framework.Rectangle((int)((double)local.X - (double)vector2.X / 2.0) + (__instance.shakeTimer > 0 ? Game1.random.Next(-1, 2) : 0), (int)((double)local.Y - (double)vector2.Y / 2.0) + (__instance.shakeTimer > 0 ? Game1.random.Next(-1, 2) : 0), (int)((double)Game1.tileSize + (double)vector2.X), (int)((double)(Game1.tileSize * 2) + (double)vector2.Y / 2.0));
             spriteBatch.Draw(Game1.bigCraftableSpriteSheet, destinationRectangle, new Microsoft.Xna.Framework.Rectangle?(SObject.getSourceRectForBigCraftable(__instance.showNextIndex.Value ? __instance.ParentSheetIndex + 1 : __instance.ParentSheetIndex)), Color.White * alpha, 0.0f, Vector2.Zero, SpriteEffects.None, (float)((double)Math.Max(0.0f, (float)((y + 1) * Game1.tileSize - Game1.pixelZoom * 6) / 10000f) + (__instance.ParentSheetIndex == 105 ? 0.00350000010803342 : 0.0) + (double)x * 9.99999974737875E-06));
             if (__instance.Name.Equals("Loom") && __instance.MinutesUntilReady > 0)
                 spriteBatch.Draw(Game1.objectSpriteSheet, __instance.getLocalPosition(Game1.viewport) + new Vector2((float)(Game1.tileSize / 2f), 0.0f), new Microsoft.Xna.Framework.Rectangle?(Game1.getSourceRectForStandardTileSheet(Game1.objectSpriteSheet, 435, 16, 16)), Color.White * alpha, __instance.scale.X, new Vector2(8f, 8f), (float)Game1.pixelZoom, SpriteEffects.None, Math.Max(0.0f, (float)((double)((y + 1) * Game1.tileSize) / 10000.0 + 9.99999974737875E-05 + (double)x * 9.99999974737875E-06)));
-            if (__instance.isLamp.Value && Game1.isDarkOut())
+            if (__instance.isLamp.Value && Game1.isDarkOut(Game1.currentLocation))
                 spriteBatch.Draw(Game1.mouseCursors, local + new Vector2((float)(-Game1.tileSize / 2f), (float)(-Game1.tileSize / 2f)), new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle(88, 1779, 32, 32)), Color.White * 0.75f, 0.0f, Vector2.Zero, (float)Game1.pixelZoom, SpriteEffects.None, Math.Max(0.0f, (float)((y + 1) * Game1.tileSize - Game1.pixelZoom * 5) / 10000f));
             if (__instance.ParentSheetIndex == 126 && __instance.Quality != 0)
                 spriteBatch.Draw(FarmerRenderer.hatsTexture, local + new Vector2(-3f, -6f) * (float)Game1.pixelZoom, new Microsoft.Xna.Framework.Rectangle?(new Microsoft.Xna.Framework.Rectangle((__instance.Quality - 1) * 20 % FarmerRenderer.hatsTexture.Width, (__instance.Quality - 1) * 20 / FarmerRenderer.hatsTexture.Width * 20 * 4, 20, 20)), Color.White * alpha, 0.0f, Vector2.Zero, (float)Game1.pixelZoom, SpriteEffects.None, Math.Max(0.0f, (float)((y + 1) * Game1.tileSize - Game1.pixelZoom * 5) / 10000f) + (float)x * 1E-05f);

--- a/BetterArtisanGoodIcons/Patches/SObjectPatches/DrawWhenHeldPatch.cs
+++ b/BetterArtisanGoodIcons/Patches/SObjectPatches/DrawWhenHeldPatch.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
 using StardewValley;
 using System;
 using SObject = StardewValley.Object;
@@ -17,8 +18,9 @@ namespace BetterArtisanGoodIcons.Patches.SObjectPatches
             //By popular demand, don't show icons when held.
             //if (iconPosition != Rectangle.Empty)
             //    spriteBatch.Draw(Game1.objectSpriteSheet, objectPosition + new Vector2(1, 1), new Microsoft.Xna.Framework.Rectangle?(iconPosition), Color.White, 0.0f, new Vector2(4f, 4f), Game1.pixelZoom / 2, SpriteEffects.None, Math.Max(0.0f, (f.getStandingY() + 2) / 10000f));
+            spriteBatch.Draw(spriteSheet, objectPosition, position, Color.White, 0.0f, Vector2.Zero, Game1.pixelZoom, SpriteEffects.None, Math.Max(0.0f, (f.StandingPixel.Y + 2) / 10000f));
+//            spriteBatch.Draw(spriteSheet, objectPosition, position, Color.White, 0f, Vector2.Zero, 4f, SpriteEffects.None, Math.Max(0f, (float)(f.StandingPixel.Y + 3) / 10000f));
 
-            spriteBatch.Draw(spriteSheet, objectPosition, position, Color.White, 0.0f, Vector2.Zero, Game1.pixelZoom, SpriteEffects.None, Math.Max(0.0f, (f.getStandingY() + 2) / 10000f));
             return false;
         }
     }

--- a/BetterArtisanGoodIcons/Patches/SObjectPatches/DrawWhenHeldPatch.cs
+++ b/BetterArtisanGoodIcons/Patches/SObjectPatches/DrawWhenHeldPatch.cs
@@ -18,9 +18,8 @@ namespace BetterArtisanGoodIcons.Patches.SObjectPatches
             //By popular demand, don't show icons when held.
             //if (iconPosition != Rectangle.Empty)
             //    spriteBatch.Draw(Game1.objectSpriteSheet, objectPosition + new Vector2(1, 1), new Microsoft.Xna.Framework.Rectangle?(iconPosition), Color.White, 0.0f, new Vector2(4f, 4f), Game1.pixelZoom / 2, SpriteEffects.None, Math.Max(0.0f, (f.getStandingY() + 2) / 10000f));
-            spriteBatch.Draw(spriteSheet, objectPosition, position, Color.White, 0.0f, Vector2.Zero, Game1.pixelZoom, SpriteEffects.None, Math.Max(0.0f, (f.StandingPixel.Y + 2) / 10000f));
-//            spriteBatch.Draw(spriteSheet, objectPosition, position, Color.White, 0f, Vector2.Zero, 4f, SpriteEffects.None, Math.Max(0f, (float)(f.StandingPixel.Y + 3) / 10000f));
 
+            spriteBatch.Draw(spriteSheet, objectPosition, position, Color.White, 0.0f, Vector2.Zero, Game1.pixelZoom, SpriteEffects.None, Math.Max(0.0f, (f.StandingPixel.Y + 2) / 10000f));
             return false;
         }
     }


### PR DESCRIPTION
BetterArtisanGoodIcons has a warning message for using deprecated SMAPI method that will be removed in SMAPI 4.0.0, this update fixed that.

The package also doesn't build with .NET 4.5.2, so it was updated to build with .NET 5.0 instead as suggested by Stardew Valley Modding guideline.